### PR TITLE
Fix js runtime issues (hopefully)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,10 +6,6 @@ gem 'rails', '~> 4.2.6'
 gem 'mysql2'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
-# Use Uglifier as compressor for JavaScript assets
-gem 'uglifier', '>= 1.3.0'
-# Use CoffeeScript for .coffee assets and views
-gem 'coffee-rails', '~> 4.1.0'
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
@@ -41,6 +37,10 @@ gem 'coveralls', require: false
 group :development, :test do
   # Call 'binding.pry' anywhere in the code to stop execution and get a debugger console
   gem 'pry'
+  # Use Uglifier as compressor for JavaScript assets
+  gem 'uglifier', '>= 1.3.0'
+  # Use CoffeeScript for .coffee assets and views
+  gem 'coffee-rails', '~> 4.1.0'
 end
 
 group :development do


### PR DESCRIPTION
These gems need to go into the development and test environment blocks
- they were causing an issue when trying to deploy to UAT, because they require a js runtime environment and there wasn't one since rubyracer was removed
