### PR TITLE
testing sm-workflow-lims against MySQL 8.4

### DIFF
--- a/.github/workflows/ruby_ci.yml
+++ b/.github/workflows/ruby_ci.yml
@@ -15,7 +15,7 @@ jobs:
     services:
       mysql:
         # Use the Mysql docker image https://hub.docker.com/_/mysql
-        image: mysql:8.0
+        image: mysql:8.4
         ports:
           - 3306:3306 # Default port mappings
           # Monitor the health of the container to mesaure when it is ready


### PR DESCRIPTION
This pull request reflects changes to mysql image from 8.0 to 8.4 in CI workflow to verify sm-workflow-lims is compatible with the MySQL 8.4 upgrade.